### PR TITLE
ELPPCKVM-840-V2: [framework] add a time to check the qemu pid in util…

### DIFF
--- a/utils_host.py
+++ b/utils_host.py
@@ -145,5 +145,6 @@ class HostSession(TestCmd):
             TestCmd.subprocess_cmd_advanced(self, cmd=cmd, vm_alias=vm_alias)
         else:
             TestCmd.subprocess_cmd_advanced(self, cmd=cmd)
+        time.sleep(3)
         dst_pid = self.get_guest_pid(cmd, dst_ip=ip)
         self.show_qemu_cmd()


### PR DESCRIPTION
…s_host.py.

Add a time sleep on the function boot_remote_guest.

Signed-off-by: Yongxue Hong <yhong@redhat.com>